### PR TITLE
Live pipeline deployment fixes

### DIFF
--- a/pipeline/Dockerfile
+++ b/pipeline/Dockerfile
@@ -13,8 +13,11 @@ COPY load.py .
 COPY prompts.py .
 COPY judge_matching.py .
 COPY judges_seed.py .
+COPY nltk_setup.py .
+
+RUN python3 nltk_setup.py
+
 
 EXPOSE 5432
-
 
 CMD ["live_pipeline.handler"]

--- a/pipeline/batch_pipeline.py
+++ b/pipeline/batch_pipeline.py
@@ -4,9 +4,12 @@ court cases to the database and cache GPT data in Redis"""
 import json
 import redis
 from rich.progress import track
+import nltk
 from extract import get_listing_data, get_max_page_num
 from transform import get_data, assemble_data
 from load import get_connection, insert_to_database
+
+nltk.download("wordnet")
 
 # Initialize Redis connection
 r = redis.Redis(host="localhost", port=6379, decode_responses=True)

--- a/pipeline/live_pipeline.py
+++ b/pipeline/live_pipeline.py
@@ -85,7 +85,6 @@ def upload_log_to_s3(aws_client: client) -> None:
 def handler(event: dict, context) -> None:
     """Main function to run the live pipeline on AWS Lambda"""
     nltk.data.path.append("./tmp")
-    print(nltk.data.path)
     aws_client = get_client()
     log_json = read_from_json(aws_client)
     log_date, log = extract_log_and_date(log_json)

--- a/pipeline/load.py
+++ b/pipeline/load.py
@@ -12,8 +12,6 @@ from Levenshtein import jaro_winkler
 from judge_matching import match_judge, get_judges
 from judges_seed import seed_judges
 
-nltk.download("wordnet")
-
 
 def synonym_extractor(phrase: str) -> set[str]:
     """Uses the wordnet module from the nltk library to find synonyms of a word"""
@@ -464,6 +462,7 @@ def insert_to_database(conn: connection, transformed_data: dict) -> str:
 
 if __name__ == "__main__":
     load_dotenv()
+    nltk.download("wordnet")
     transform = {
         "verdicts": ["Dismissed", "Dismissed"],
         "courts": [

--- a/pipeline/nltk_setup.py
+++ b/pipeline/nltk_setup.py
@@ -1,0 +1,6 @@
+"""Python script to initialise download of wordnet model for NLTK"""
+
+import nltk
+
+if __name__ == "__main__":
+    nltk.download("wordnet", download_dir="./tmp")


### PR DESCRIPTION
Hi team,

This pull request is for changes made to get the live_pipeline lambda function working on AWS including optimisations regarding the installation of the wordnet model for nltk (running it once as part of the image build process as opposed on every container run).

Summary of changes:

- Created new file called `nltk_setup.py` that installs the wordnet model.

- Dockerfile now calls `nltk_setup.py` using `RUN` during image build.

- AWS Lambda can only read and write files from the `/tmp/ `directory, changes made to extract to add the required prefix.

- Moved nltk model installation in `load.py` into `if __name__ == "__main__"` block so it is not called when load is imported in live pipeline.

- Added nltk model installation in the batch pipeline as a result of its removal from the main code block in load.


Contributors: Linfan, Hamoodi