### PR TITLE
Added GPT API cost calculation

### DIFF
--- a/pipeline/calculate_gpt_cost.py
+++ b/pipeline/calculate_gpt_cost.py
@@ -1,0 +1,31 @@
+"""Python script to calculate the total cost of using the GPT-4o-mini model on the batch pipeline"""
+
+from ast import literal_eval
+
+INPUT_COST_PER_MILLION_TOKENS = 0.15
+OUTPUT_COST_PER_MILLION_TOKENS = 0.60
+
+
+def calculate_cost(file_name):
+    """Calculate the total cost of using the GPT-4o-mini model"""
+    output_tokens, input_tokens = 0, 0
+
+    with open(file_name, "r", encoding="utf-8") as f:
+        lines = f.readlines()
+
+    for line in lines:
+        if "GPT-4o-mini usage cost:" in line:
+            cost_string = line.split(": ")[1]
+            cost_list = literal_eval(cost_string)
+            output_tokens += cost_list[0]
+            input_tokens += cost_list[1]
+
+    output_cost = (output_tokens / 1000000) * OUTPUT_COST_PER_MILLION_TOKENS
+    input_cost = (input_tokens / 1000000) * INPUT_COST_PER_MILLION_TOKENS
+    total_cost = output_cost + input_cost
+    total_cost_usd = f"${total_cost:.2f}"
+    return total_cost_usd
+
+
+if __name__ == "__main__":
+    print(calculate_cost("batch_pipeline.log"))  # $15.71

--- a/pipeline/calculate_gpt_cost.py
+++ b/pipeline/calculate_gpt_cost.py
@@ -2,6 +2,7 @@
 
 from ast import literal_eval
 
+# pricing info available at https://openai.com/api/pricing/
 INPUT_COST_PER_MILLION_TOKENS = 0.15
 OUTPUT_COST_PER_MILLION_TOKENS = 0.60
 
@@ -22,6 +23,8 @@ def calculate_cost(file_name):
 
     output_cost = (output_tokens / 1000000) * OUTPUT_COST_PER_MILLION_TOKENS
     input_cost = (input_tokens / 1000000) * INPUT_COST_PER_MILLION_TOKENS
+    print(f"Output cost: ${output_cost:.2f}")
+    print(f"Input cost: ${input_cost:.2f}")
     total_cost = output_cost + input_cost
     total_cost_usd = f"${total_cost:.2f}"
     return total_cost_usd


### PR DESCRIPTION
Hi,

This pull request for the addition of a quick script to iterate through the lines of the console logs from running the batch pipeline, isolating the list of values related to the token usage for the ChatGPT API and calculates the total cost in USD.

Doesn't account of course for additional cost of testing and developing the pipeline and ~~having to run the batch pipeline again after realising it's not working~~ but a cost figure is a nice to have metric to presenting to stakeholders.